### PR TITLE
Feature: Highlighting another author's code

### DIFF
--- a/BlameHighlight.sublime-settings
+++ b/BlameHighlight.sublime-settings
@@ -3,5 +3,6 @@
 	// 
 	// If you're on Linux/OSX you can provide a direct path to a git binary as well. If set to "false" it picks
 	// up git from your $PATH
-    "git_command": false
+    "git_command": false,
+    "author_email": false // Replace with another Git author's email to highlight
 }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,60 @@
+[
+    {
+        "id": "tools",
+        "children":
+        [
+            {
+                "id": "end"
+            },
+            {
+                "caption": "Blame Highlighter",
+                "children":
+                [
+                    {
+                        "caption": "Highlight code from git blame",
+                        "command": "see_my_code"
+                    },
+                    {
+                        "caption": "Remove code highlight",
+                        "command": "clear_blame_highlights"
+                    },
+                    {
+                        "caption": "-"
+                    },
+                    {
+                        "caption": "Settings - User",
+                        "command": "open_file",
+                        "args"   : {"file" : "${packages}/User/BlameHighlight.sublime-settings"}
+                    }
+                ]
+            },
+        ]
+    },
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Blame Highlighter",
+                        "children":
+                        [
+                            {
+                                "caption": "Settings – User",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/BlameHighlight.sublime-settings"}
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/blamehighlight.py
+++ b/blamehighlight.py
@@ -57,7 +57,10 @@ class SeeMyCode(sublime_plugin.TextCommand):
 		dirName = os.path.dirname(fileName)
 		os.chdir(dirName)
 		if get_return_code([git_command, "rev-parse"]) == 0:
-			email = get_stdout_string([git_command, "config", "user.email"])
+			if self.settings.get ("author_email"):
+				email = self.settings.get ("author_email")
+			else :
+				email = get_stdout_string([git_command, "config", "user.email"])
 			email = email.splitlines()
 			email = email[0]
 			gitLines = extract_user_lines(dirName, fileName, email, git_command)


### PR DESCRIPTION
Added the following customisation:
- Enable highlighting of another user's code with the setting `author_email`
- Add menu entries under `Tools`
